### PR TITLE
fix: missing commas in landsat products conformsTo

### DIFF
--- a/stapi_fastapi_landsat/backend.py
+++ b/stapi_fastapi_landsat/backend.py
@@ -20,8 +20,8 @@ PRODUCTS = [
     Product(
         id="landsat:8",
         conformsTo=[
-            "https://geojson.org/schema/Point.json"
-            "https://geojson.org/schema/Polygon.json"
+            "https://geojson.org/schema/Point.json",
+            "https://geojson.org/schema/Polygon.json",
         ],
         description="Landsat 8",
         license="CC0-1.0",
@@ -43,8 +43,8 @@ PRODUCTS = [
     Product(
         id="landsat:9",
         conformsTo=[
-            "https://geojson.org/schema/Point.json"
-            "https://geojson.org/schema/Polygon.json"
+            "https://geojson.org/schema/Point.json",
+            "https://geojson.org/schema/Polygon.json",
         ],
         description="Landsat 9",
         license="CC0-1.0",


### PR DESCRIPTION
Looks like this was an inadvertently missed comma, the result of which is that the two strings are concatenated rather than being separate list elements.