### PR TITLE
feat: separate product meta and product schema

### DIFF
--- a/stapi_fastapi/api.py
+++ b/stapi_fastapi/api.py
@@ -117,20 +117,26 @@ class StapiRouter:
 
     def products(self, request: Request) -> ProductsCollection:
         products = self.backend.products(request)
-        for product in products:
-            product.links.append(
-                Link(
-                    href=str(
-                        request.url_for(
-                            f"{self.NAME_PREFIX}:get-product", product_id=product.id
-                        )
-                    ),
-                    rel="self",
-                    type=TYPE_JSON,
-                )
-            )
+
         return ProductsCollection(
-            products=products,
+            products=[
+                Product.from_meta(
+                    product,
+                    links=[
+                        Link(
+                            href=str(
+                                request.url_for(
+                                    f"{self.NAME_PREFIX}:get-product",
+                                    product_id=product.id,
+                                )
+                            ),
+                            rel="self",
+                            type=TYPE_JSON,
+                        )
+                    ],
+                )
+                for product in products
+            ],
             links=[
                 Link(
                     href=str(request.url_for(f"{self.NAME_PREFIX}:list-products")),
@@ -147,18 +153,21 @@ class StapiRouter:
             raise StapiException(
                 status.HTTP_404_NOT_FOUND, "product not found"
             ) from exc
-        product.links.append(
-            Link(
-                href=str(
-                    request.url_for(
-                        f"{self.NAME_PREFIX}:get-product", product_id=product.id
-                    )
-                ),
-                rel="self",
-                type=TYPE_JSON,
-            )
+
+        return Product.from_meta(
+            product,
+            links=[
+                Link(
+                    href=str(
+                        request.url_for(
+                            f"{self.NAME_PREFIX}:get-product", product_id=product.id
+                        )
+                    ),
+                    rel="self",
+                    type=TYPE_JSON,
+                )
+            ],
         )
-        return product
 
     async def search_opportunities(
         self, search: OpportunityRequest, request: Request

--- a/stapi_fastapi/backend.py
+++ b/stapi_fastapi/backend.py
@@ -4,16 +4,16 @@ from fastapi import Request
 
 from stapi_fastapi.models.opportunity import Opportunity, OpportunityRequest
 from stapi_fastapi.models.order import Order
-from stapi_fastapi.models.product import Product
+from stapi_fastapi.models.product import ProductMeta
 
 
 class StapiBackend(Protocol):
-    def products(self, request: Request) -> list[Product]:
+    def products(self, request: Request) -> list[ProductMeta]:
         """
         Return a list of supported products.
         """
 
-    def product(self, product_id: str, request: Request) -> Product | None:
+    def product(self, product_id: str, request: Request) -> ProductMeta | None:
         """
         Return the product identified by `product_id` or `None` if it isn't
         supported.

--- a/stapi_fastapi/models/product.py
+++ b/stapi_fastapi/models/product.py
@@ -1,3 +1,4 @@
+from copy import copy
 from enum import Enum
 from typing import Literal, Optional
 
@@ -21,8 +22,11 @@ class Provider(BaseModel):
     url: AnyHttpUrl
 
 
-class Product(BaseModel):
-    type: Literal["Product"] = "Product"
+class ProductMeta(BaseModel):
+    """
+    Product metadata
+    """
+
     conformsTo: list[str] = Field(default_factory=list)
     id: str
     title: str = ""
@@ -30,11 +34,29 @@ class Product(BaseModel):
     keywords: list[str] = Field(default_factory=list)
     license: str
     providers: list[Provider] = Field(default_factory=list)
-    links: list[Link]
     parameters: JsonSchemaModel
 
 
+class Product(ProductMeta):
+    """
+    Product schema for JSON responses
+    """
+
+    type: Literal["Product"] = "Product"
+    links: list[Link]
+
+    @classmethod
+    def from_meta(cls, meta: ProductMeta, links: list[Link] = []):
+        attribs = copy(meta.__dict__)
+        attribs |= {"links": links}
+        return cls(**attribs)
+
+
 class ProductsCollection(BaseModel):
+    """
+    Products collection schema for JSON responses
+    """
+
     type: Literal["ProductCollection"] = "ProductCollection"
     links: list[Link] = Field(default_factory=list)
     products: list[Product]

--- a/stapi_fastapi_landsat/backend.py
+++ b/stapi_fastapi_landsat/backend.py
@@ -13,11 +13,11 @@ from stapi_fastapi.models.opportunity import (
     OpportunityRequest,
 )
 from stapi_fastapi.models.order import Order
-from stapi_fastapi.models.product import Product, Provider, ProviderRole
+from stapi_fastapi.models.product import ProductMeta, Provider, ProviderRole
 from stapi_fastapi_landsat.models import Constraints
 
 PRODUCTS = [
-    Product(
+    ProductMeta(
         id="landsat:8",
         conformsTo=[
             "https://geojson.org/schema/Point.json",
@@ -38,9 +38,8 @@ PRODUCTS = [
             )
         ],
         parameters=Constraints,
-        links=[],
     ),
-    Product(
+    ProductMeta(
         id="landsat:9",
         conformsTo=[
             "https://geojson.org/schema/Point.json",
@@ -61,7 +60,6 @@ PRODUCTS = [
             )
         ],
         parameters=Constraints,
-        links=[],
     ),
 ]
 
@@ -78,13 +76,13 @@ class LandsatBackend:
         }
         self.satellite = self._load_json("stapi_fastapi_landsat/files/satellites.json")
 
-    def products(self, request: Request) -> list[Product]:
+    def products(self, request: Request) -> list[ProductMeta]:
         """
         Return a list of supported products.
         """
         return PRODUCTS
 
-    def product(self, product_id: str, request: Request) -> Product | None:
+    def product(self, product_id: str, request: Request) -> ProductMeta | None:
         """
         Return the product identified by `product_id` or `None` if it isn't
         supported.

--- a/stapi_fastapi_test_backend/backend.py
+++ b/stapi_fastapi_test_backend/backend.py
@@ -6,22 +6,22 @@ from fastapi import Request
 from stapi_fastapi.exceptions import ConstraintsException, NotFoundException
 from stapi_fastapi.models.opportunity import Opportunity, OpportunityRequest
 from stapi_fastapi.models.order import Order
-from stapi_fastapi.models.product import Product
+from stapi_fastapi.models.product import ProductMeta
 
 
 class TestBackend:
-    _products: list[Product] = []
+    _products: list[ProductMeta] = []
     _opportunities: list[Opportunity] = []
     _allowed_payloads: list[OpportunityRequest] = []
     _orders: Mapping[str, Order] = {}
 
-    def products(self, request: Request) -> list[Product]:
+    def products(self, request: Request) -> list[ProductMeta]:
         """
         Return a list of supported products.
         """
         return self._products
 
-    def product(self, product_id: str, request: Request) -> Product | None:
+    def product(self, product_id: str, request: Request) -> ProductMeta | None:
         """
         Return the product identified by `product_id` or `None` if it isn't
         supported.

--- a/stapi_fastapi_tle_backend/backend.py
+++ b/stapi_fastapi_tle_backend/backend.py
@@ -4,7 +4,7 @@ from pydantic import BaseModel, Field, ValidationError, model_validator
 from stapi_fastapi.exceptions import ConstraintsException, NotFoundException
 from stapi_fastapi.models.opportunity import Opportunity, OpportunityRequest
 from stapi_fastapi.models.order import Order
-from stapi_fastapi.models.product import Product, Provider, ProviderRole
+from stapi_fastapi.models.product import ProductMeta, Provider, ProviderRole
 from stapi_fastapi_tle_backend.models import ValidatedOpportunityRequest
 from stapi_fastapi_tle_backend.repository import Repository
 from stapi_fastapi_tle_backend.satellite import EarthObservationSatelliteModel
@@ -28,7 +28,7 @@ class Parameters(BaseModel):
 
 
 PRODUCTS = [
-    Product(
+    ProductMeta(
         id="mock:standard",
         description="Mock backend's standard product",
         license="CC0-1.0",
@@ -44,7 +44,6 @@ PRODUCTS = [
                 url="http://acme.example.com",
             )
         ],
-        links=[],
         parameters=Parameters,
     )
 ]
@@ -59,13 +58,13 @@ class StapiMockBackend:
         self.repository = Repository(settings.database)
         self.satellite = EarthObservationSatelliteModel(settings.satellite)
 
-    def products(self, request: Request) -> list[Product]:
+    def products(self, request: Request) -> list[ProductMeta]:
         """
         Return a list of supported products.
         """
         return PRODUCTS
 
-    def product(self, product_id: str, request: Request) -> Product | None:
+    def product(self, product_id: str, request: Request) -> ProductMeta | None:
         """
         Return the product identified by `product_id` or `None` if it isn't
         supported.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel
 from pytest import fixture
 
 from stapi_fastapi.models.opportunity import Opportunity, OpportunityRequest
-from stapi_fastapi.models.product import Product, Provider, ProviderRole
+from stapi_fastapi.models.product import ProductMeta, Provider, ProviderRole
 
 
 @fixture
@@ -14,7 +14,7 @@ def products():
         pass
 
     yield [
-        Product(
+        ProductMeta(
             id="mock:standard",
             description="Mock backend's standard product",
             license="CC0-1.0",
@@ -31,13 +31,12 @@ def products():
                 )
             ],
             parameters=Parameters,
-            links=[],
         )
     ]
 
 
 @fixture
-def opportunities(products: list[Product]):
+def opportunities(products: list[ProductMeta]):
     yield [
         Opportunity(
             geometry=Point(type="Point", coordinates=[13.4, 52.5]),
@@ -51,7 +50,7 @@ def opportunities(products: list[Product]):
 
 
 @fixture
-def allowed_payloads(products: list[Product]):
+def allowed_payloads(products: list[ProductMeta]):
     yield [
         OpportunityRequest(
             geometry=Point(type="Point", coordinates=[13.4, 52.5]),

--- a/tests/product_test.py
+++ b/tests/product_test.py
@@ -3,7 +3,7 @@ from warnings import warn
 from fastapi import status
 from fastapi.testclient import TestClient
 
-from stapi_fastapi.models.product import Product
+from stapi_fastapi.models.product import ProductMeta
 from stapi_fastapi_test_backend.backend import TestBackend
 
 from .utils import find_link
@@ -23,7 +23,7 @@ def test_products_response(stapi_client: TestClient):
 
 
 def test_product_response_self_link(
-    products: list[Product],
+    products: list[ProductMeta],
     stapi_backend: TestBackend,
     stapi_client: TestClient,
     url_for,


### PR DESCRIPTION
separating product metadata (as needs to be defined by provider implementation) and schema used in the endpoints (with links added automatically)