### PR TITLE
fixes pip install as editable package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ description = "Spatio Temporal Asset Tasking with FastAPI"
 authors = ["Christian Wygoda <christian.wygoda@wygoda.net>"]
 license = "MIT"
 readme = "README.md"
+packages = [{include = "stapi_fastapi", from="src"}]
 
 [tool.poetry.dependencies]
 python = "3.12.*"


### PR DESCRIPTION
When running `poetry install --with dev`, after installing dependencies, and attempt to install stapi_fastapi results in a warning:

"stapi_fastapi is not a package."

Following that, attempting to `pip install -e .` results in failure to build installable wheels for stapi-fastapi.

This fix adds `stapi-fastapi` as a package in the pyproject.toml.

Credit @jkeifer for helping me with this fix.