### PR TITLE
Fixes tags on /products routes to be Products instead of Product or undefined

### DIFF
--- a/src/stapi_fastapi/routers/product_router.py
+++ b/src/stapi_fastapi/routers/product_router.py
@@ -39,6 +39,7 @@ class ProductRouter(APIRouter):
             name=f"{self.root_router.name}:{self.product.id}:get-product",
             methods=["GET"],
             summary="Retrieve this product",
+            tags=["Products"],
         )
 
         self.add_api_route(
@@ -49,6 +50,7 @@ class ProductRouter(APIRouter):
             response_class=GeoJSONResponse,
             response_model=OpportunityCollection[Geometry, self.product.constraints],
             summary="Search Opportunities for the product",
+            tags=["Products"],
         )
 
         self.add_api_route(
@@ -57,6 +59,7 @@ class ProductRouter(APIRouter):
             name=f"{self.root_router.name}:{self.product.id}:get-constraints",
             methods=["GET"],
             summary="Get constraints for the product",
+            tags=["Products"],
         )
 
         self.add_api_route(
@@ -67,6 +70,7 @@ class ProductRouter(APIRouter):
             response_class=GeoJSONResponse,
             status_code=status.HTTP_201_CREATED,
             summary="Create an order for the product",
+            tags=["Products"],
         )
 
     def get_product(self, request: Request) -> Product:

--- a/src/stapi_fastapi/routers/root_router.py
+++ b/src/stapi_fastapi/routers/root_router.py
@@ -48,7 +48,7 @@ class RootRouter(APIRouter):
             self.get_products,
             methods=["GET"],
             name=f"{self.name}:list-products",
-            tags=["Product"],
+            tags=["Products"],
         )
 
         self.add_api_route(


### PR DESCRIPTION
Fixes tags on /products routes to be `Products` (as defined in the STAPI spec) instead of `Product` or undefined