### PR TITLE
add product_id field to Opportunity and Order Properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - Conformance endpoint `/conformance` and root body `conformsTo` attribute.
+- Field `product_id` to Opportunity and Order Properties
 
 ### Changed
 

--- a/src/stapi_fastapi/models/opportunity.py
+++ b/src/stapi_fastapi/models/opportunity.py
@@ -11,6 +11,7 @@ from stapi_fastapi.types.filter import CQL2Filter
 
 # Copied and modified from https://github.com/stac-utils/stac-pydantic/blob/main/stac_pydantic/item.py#L11
 class OpportunityPropertiesBase(BaseModel):
+    product_id: str
     datetime: DatetimeInterval
     model_config = ConfigDict(extra="allow")
 

--- a/src/stapi_fastapi/models/order.py
+++ b/src/stapi_fastapi/models/order.py
@@ -9,6 +9,7 @@ from stapi_fastapi.types.datetime_interval import DatetimeInterval
 
 
 class OrderProperties(BaseModel):
+    product_id: str
     datetime: DatetimeInterval
     model_config = ConfigDict(extra="allow")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -137,6 +137,7 @@ def mock_test_spotlight_opportunities() -> list[Opportunity]:
                 coordinates=Position2D(longitude=0.0, latitude=0.0),
             ),
             properties=TestSpotlightProperties(
+                product_id="xyz123",
                 datetime=(start, end),
                 off_nadir=20,
             ),


### PR DESCRIPTION
**Related Issue(s):**

- https://github.com/stapi-spec/stapi-fastapi/issues/94

**Proposed Changes:**

1. add product_id field to Opportunity and Order Properties

**PR Checklist:**

- [X] I have added my changes to the [CHANGELOG](https://github.com/Element84/filmdrop-ui/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.
