### PR TITLE
add product order-parameters endpoint and links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - Conformance endpoint `/conformance` and root body `conformsTo` attribute.
+- Endpoint /product/{productId}/order-parameters.
+- Links in Product entity to order-parameters and constraints endpoints for that product.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Conformance endpoint `/conformance` and root body `conformsTo` attribute.
 - Endpoint /product/{productId}/order-parameters.
 - Links in Product entity to order-parameters and constraints endpoints for that product.
+- Add links `opportunities` and `create-order` to Product
+- Add link `create-order` to OpportunityCollection
 
 ### Changed
 

--- a/bin/server.py
+++ b/bin/server.py
@@ -13,6 +13,7 @@ from stapi_fastapi.models.opportunity import (
 )
 from stapi_fastapi.models.order import Order, OrderCollection
 from stapi_fastapi.models.product import (
+    OrderParameters,
     Product,
     Provider,
     ProviderRole,
@@ -82,6 +83,10 @@ class TestSpotlightProperties(OpportunityPropertiesBase):
     off_nadir: int
 
 
+class TestSpotlightOrderParameters(OrderParameters):
+    delivery_mechanism: str | None = None
+
+
 order_db = MockOrderDB()
 product_backend = MockProductBackend(order_db)
 root_backend = MockRootBackend(order_db)
@@ -102,6 +107,7 @@ product = Product(
     providers=[provider],
     links=[],
     constraints=TestSpotlightProperties,
+    order_parameters=TestSpotlightOrderParameters,
     backend=product_backend,
 )
 

--- a/src/stapi_fastapi/models/product.py
+++ b/src/stapi_fastapi/models/product.py
@@ -4,7 +4,7 @@ from copy import deepcopy
 from enum import Enum
 from typing import TYPE_CHECKING, Literal, Optional, Self
 
-from pydantic import AnyHttpUrl, BaseModel, Field
+from pydantic import AnyHttpUrl, BaseModel, ConfigDict, Field
 
 from stapi_fastapi.models.opportunity import OpportunityPropertiesBase
 from stapi_fastapi.models.shared import Link
@@ -32,6 +32,10 @@ class Provider(BaseModel):
         super().__init__(url=url, **kwargs)
 
 
+class OrderParameters(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+
 class Product(BaseModel):
     type_: Literal["Product"] = Field(default="Product", alias="type")
     conformsTo: list[str] = Field(default_factory=list)
@@ -45,6 +49,7 @@ class Product(BaseModel):
 
     # we don't want to include these in the model fields
     _constraints: type[OpportunityPropertiesBase]
+    _order_parameters: type[OrderParameters]
     _backend: ProductBackend
 
     def __init__(
@@ -52,11 +57,13 @@ class Product(BaseModel):
         *args,
         backend: ProductBackend,
         constraints: type[OpportunityPropertiesBase],
+        order_parameters: type[OrderParameters],
         **kwargs,
     ) -> None:
         super().__init__(*args, **kwargs)
         self._backend = backend
         self._constraints = constraints
+        self._order_parameters = order_parameters
 
     @property
     def backend(self: Self) -> ProductBackend:
@@ -65,6 +72,10 @@ class Product(BaseModel):
     @property
     def constraints(self: Self) -> type[OpportunityPropertiesBase]:
         return self._constraints
+
+    @property
+    def order_parameters(self: Self) -> type[OrderParameters]:
+        return self._order_parameters
 
     def with_links(self: Self, links: list[Link] | None = None) -> Self:
         if not links:

--- a/src/stapi_fastapi/routers/product_router.py
+++ b/src/stapi_fastapi/routers/product_router.py
@@ -113,6 +113,24 @@ class ProductRouter(APIRouter):
                     rel="order-parameters",
                     type=TYPE_JSON,
                 ),
+                Link(
+                    href=str(
+                        request.url_for(
+                            f"{self.root_router.name}:{self.product.id}:search-opportunities",
+                        ),
+                    ),
+                    rel="opportunities",
+                    type=TYPE_JSON,
+                ),
+                Link(
+                    href=str(
+                        request.url_for(
+                            f"{self.root_router.name}:{self.product.id}:create-order",
+                        ),
+                    ),
+                    rel="create-order",
+                    type=TYPE_JSON,
+                ),
             ],
         )
 
@@ -129,7 +147,20 @@ class ProductRouter(APIRouter):
         except ConstraintsException as exc:
             raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, detail=exc.detail)
 
-        return OpportunityCollection(features=opportunities)
+        return OpportunityCollection(
+            features=opportunities,
+            links=[
+                Link(
+                    href=str(
+                        request.url_for(
+                            f"{self.root_router.name}:{self.product.id}:create-order",
+                        ),
+                    ),
+                    rel="create-order",
+                    type=TYPE_JSON,
+                ),
+            ],
+        )
 
     async def get_product_constraints(self: Self) -> JsonSchemaModel:
         """

--- a/src/stapi_fastapi/routers/product_router.py
+++ b/src/stapi_fastapi/routers/product_router.py
@@ -64,6 +64,15 @@ class ProductRouter(APIRouter):
         )
 
         self.add_api_route(
+            path="/order-parameters",
+            endpoint=self.get_product_order_parameters,
+            name=f"{self.root_router.name}:{self.product.id}:get-order-parameters",
+            methods=["GET"],
+            summary="Get order parameters for the product",
+            tags=["Products"],
+        )
+
+        self.add_api_route(
             path="/order",
             endpoint=self.create_order,
             name=f"{self.root_router.name}:{self.product.id}:create-order",
@@ -84,6 +93,24 @@ class ProductRouter(APIRouter):
                         ),
                     ),
                     rel="self",
+                    type=TYPE_JSON,
+                ),
+                Link(
+                    href=str(
+                        request.url_for(
+                            f"{self.root_router.name}:{self.product.id}:get-constraints",
+                        ),
+                    ),
+                    rel="constraints",
+                    type=TYPE_JSON,
+                ),
+                Link(
+                    href=str(
+                        request.url_for(
+                            f"{self.root_router.name}:{self.product.id}:get-order-parameters",
+                        ),
+                    ),
+                    rel="order-parameters",
                     type=TYPE_JSON,
                 ),
             ],
@@ -109,6 +136,12 @@ class ProductRouter(APIRouter):
         Return supported constraints of a specific product
         """
         return self.product.constraints
+
+    async def get_product_order_parameters(self: Self) -> JsonSchemaModel:
+        """
+        Return supported constraints of a specific product
+        """
+        return self.product.order_parameters
 
     async def create_order(
         self, payload: OpportunityRequest, request: Request, response: Response

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,12 @@ from stapi_fastapi.models.opportunity import (
     OpportunityPropertiesBase,
     OpportunityRequest,
 )
-from stapi_fastapi.models.product import Product, Provider, ProviderRole
+from stapi_fastapi.models.product import (
+    OrderParameters,
+    Product,
+    Provider,
+    ProviderRole,
+)
 from stapi_fastapi.routers.root_router import RootRouter
 
 from .backends import MockOrderDB, MockProductBackend, MockRootBackend
@@ -24,6 +29,10 @@ from .utils import find_link
 
 class TestSpotlightProperties(OpportunityPropertiesBase):
     off_nadir: int
+
+
+class TestSpotlightOrderParameters(OrderParameters):
+    delivery_mechanism: str | None = None
 
 
 @pytest.fixture(scope="session")
@@ -60,6 +69,7 @@ def mock_product_test_spotlight(
         providers=[mock_provider],
         links=[],
         constraints=TestSpotlightProperties,
+        order_parameters=TestSpotlightOrderParameters,
         backend=product_backend,
     )
 

--- a/tests/opportunity_test.py
+++ b/tests/opportunity_test.py
@@ -3,7 +3,6 @@ from typing import List
 
 import pytest
 from fastapi.testclient import TestClient
-
 from stapi_fastapi.models.opportunity import Opportunity, OpportunityCollection
 
 from .backends import MockProductBackend
@@ -16,6 +15,7 @@ def test_search_opportunities_response(
     mock_test_spotlight_opportunities: List[Opportunity],
     product_backend: MockProductBackend,
     stapi_client: TestClient,
+    assert_link
 ) -> None:
     product_backend._opportunities = mock_test_spotlight_opportunities
 
@@ -50,9 +50,11 @@ def test_search_opportunities_response(
 
     # Validate response status and structure
     assert response.status_code == 200, f"Failed for product: {product_id}"
-    _json = response.json()
+    body = response.json()
 
     try:
-        OpportunityCollection(**_json)
+        oc = OpportunityCollection(**body)
     except Exception as _:
         pytest.fail("response is not an opportunity collection")
+
+    assert_link(f"POST {url}", body, "create-order", f"/products/{product_id}/order")

--- a/tests/opportunity_test.py
+++ b/tests/opportunity_test.py
@@ -3,6 +3,7 @@ from typing import List
 
 import pytest
 from fastapi.testclient import TestClient
+
 from stapi_fastapi.models.opportunity import Opportunity, OpportunityCollection
 
 from .backends import MockProductBackend
@@ -15,7 +16,7 @@ def test_search_opportunities_response(
     mock_test_spotlight_opportunities: List[Opportunity],
     product_backend: MockProductBackend,
     stapi_client: TestClient,
-    assert_link
+    assert_link,
 ) -> None:
     product_backend._opportunities = mock_test_spotlight_opportunities
 
@@ -53,7 +54,7 @@ def test_search_opportunities_response(
     body = response.json()
 
     try:
-        oc = OpportunityCollection(**body)
+        _ = OpportunityCollection(**body)
     except Exception as _:
         pytest.fail("response is not an opportunity collection")
 

--- a/tests/product_test.py
+++ b/tests/product_test.py
@@ -2,8 +2,6 @@ import pytest
 from fastapi import status
 from fastapi.testclient import TestClient
 
-from .utils import find_link
-
 
 def test_products_response(stapi_client: TestClient):
     res = stapi_client.get("/products")
@@ -21,17 +19,20 @@ def test_products_response(stapi_client: TestClient):
 def test_product_response_self_link(
     product_id: str,
     stapi_client: TestClient,
-    url_for,
+    assert_link,
 ):
     res = stapi_client.get(f"/products/{product_id}")
     assert res.status_code == status.HTTP_200_OK
     assert res.headers["Content-Type"] == "application/json"
 
-    data = res.json()
-    link = find_link(data["links"], "self")
-    assert link, "GET /products Link[rel=self] should exist"
-    assert link["type"] == "application/json"
-    assert link["href"] == url_for(f"/products/{product_id}")
+    body = res.json()
+
+    url = "GET /products"
+    assert_link(url, body, "self", f"/products/{product_id}")
+    assert_link(url, body, "constraints", f"/products/{product_id}/constraints")
+    assert_link(
+        url, body, "order-parameters", f"/products/{product_id}/order-parameters"
+    )
 
 
 @pytest.mark.parametrize("product_id", ["test-spotlight"])
@@ -43,7 +44,21 @@ def test_product_constraints_response(
     assert res.status_code == status.HTTP_200_OK
     assert res.headers["Content-Type"] == "application/json"
 
-    data = res.json()
-    assert "properties" in data
-    assert "datetime" in data["properties"]
-    assert "off_nadir" in data["properties"]
+    json_schema = res.json()
+    assert "properties" in json_schema
+    assert "datetime" in json_schema["properties"]
+    assert "off_nadir" in json_schema["properties"]
+
+
+@pytest.mark.parametrize("product_id", ["test-spotlight"])
+def test_product_order_parameters_response(
+    product_id: str,
+    stapi_client: TestClient,
+):
+    res = stapi_client.get(f"/products/{product_id}/order-parameters")
+    assert res.status_code == status.HTTP_200_OK
+    assert res.headers["Content-Type"] == "application/json"
+
+    json_schema = res.json()
+    assert "properties" in json_schema
+    assert "delivery_mechanism" in json_schema["properties"]

--- a/tests/product_test.py
+++ b/tests/product_test.py
@@ -33,6 +33,12 @@ def test_product_response_self_link(
     assert_link(
         url, body, "order-parameters", f"/products/{product_id}/order-parameters"
     )
+    assert_link(
+        url, body, "opportunities", f"/products/{product_id}/opportunities"
+    )
+    assert_link(
+        url, body, "create-order", f"/products/{product_id}/order"
+    )
 
 
 @pytest.mark.parametrize("product_id", ["test-spotlight"])

--- a/tests/product_test.py
+++ b/tests/product_test.py
@@ -33,12 +33,8 @@ def test_product_response_self_link(
     assert_link(
         url, body, "order-parameters", f"/products/{product_id}/order-parameters"
     )
-    assert_link(
-        url, body, "opportunities", f"/products/{product_id}/opportunities"
-    )
-    assert_link(
-        url, body, "create-order", f"/products/{product_id}/order"
-    )
+    assert_link(url, body, "opportunities", f"/products/{product_id}/opportunities")
+    assert_link(url, body, "create-order", f"/products/{product_id}/order")
 
 
 @pytest.mark.parametrize("product_id", ["test-spotlight"])


### PR DESCRIPTION
**Related Issue(s):**

- https://github.com/stapi-spec/stapi-fastapi/issues/87 (does not fully complete this issue)
- https://github.com/stapi-spec/stapi-fastapi/issues/96
- https://github.com/stapi-spec/stapi-fastapi/issues/92

**Proposed Changes:**

1. Add endpoint /product/{productId}/order-parameters
2. Add links in Product entity to order-parameters and constraints

**PR Checklist:**

- [X] I have added my changes to the [CHANGELOG](https://github.com/Element84/filmdrop-ui/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.
