### PR TITLE
change create-order endpoint from .../order to .../orders to follow web API conventions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ none
 
 ### Changed
 
-none
+- Create Order endpoint from `.../order` to `.../orders`
 
 ### Deprecated
 

--- a/src/stapi_fastapi/routers/product_router.py
+++ b/src/stapi_fastapi/routers/product_router.py
@@ -91,7 +91,7 @@ class ProductRouter(APIRouter):
         ]
 
         self.add_api_route(
-            path="/order",
+            path="/orders",
             endpoint=_create_order,
             name=f"{self.root_router.name}:{self.product.id}:create-order",
             methods=["POST"],

--- a/tests/opportunity_test.py
+++ b/tests/opportunity_test.py
@@ -58,4 +58,4 @@ def test_search_opportunities_response(
     except Exception as _:
         pytest.fail("response is not an opportunity collection")
 
-    assert_link(f"POST {url}", body, "create-order", f"/products/{product_id}/order")
+    assert_link(f"POST {url}", body, "create-order", f"/products/{product_id}/orders")

--- a/tests/order_test.py
+++ b/tests/order_test.py
@@ -44,7 +44,7 @@ def new_order_response(
     product_backend._allowed_payloads = create_order_allowed_payloads
 
     res = stapi_client.post(
-        f"products/{product_id}/order",
+        f"products/{product_id}/orders",
         json=create_order_allowed_payloads[0].model_dump(),
     )
 

--- a/tests/product_test.py
+++ b/tests/product_test.py
@@ -34,7 +34,7 @@ def test_product_response_self_link(
         url, body, "order-parameters", f"/products/{product_id}/order-parameters"
     )
     assert_link(url, body, "opportunities", f"/products/{product_id}/opportunities")
-    assert_link(url, body, "create-order", f"/products/{product_id}/order")
+    assert_link(url, body, "create-order", f"/products/{product_id}/orders")
 
 
 @pytest.mark.parametrize("product_id", ["test-spotlight"])


### PR DESCRIPTION
**Related Issue(s):**

- n/a

**Proposed Changes:**

1. change create-order endpoint from .../order to .../orders to follow web API conventions, and match with changes from stapi-spec

**PR Checklist:**

- [X] I have added my changes to the [CHANGELOG](https://github.com/Element84/filmdrop-ui/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.
