### PR TITLE
copy product with pydantic model_copy instead of copy.deepcopy

### DIFF
--- a/src/stapi_fastapi/models/product.py
+++ b/src/stapi_fastapi/models/product.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from copy import deepcopy
 from enum import Enum
 from typing import TYPE_CHECKING, Literal, Optional, Self
 
@@ -78,7 +77,7 @@ class Product(BaseModel):
         if not links:
             return self
 
-        new = deepcopy(self)
+        new = self.model_copy(deep=True)
         new.links.extend(links)
         return new
 


### PR DESCRIPTION
**Related Issue(s):**

- n/a

**Proposed Changes:**

copy product with pydantic model_copy instead of copy.deepcopy

I hit an error with this after some changes that I think monkeypatched a class. I don't know if the error is related to this or not, but it would be better to do this copy the Pydantic way rathe than the generic way.

**PR Checklist:**

- [X] I have added my changes to the [CHANGELOG](https://github.com/Element84/filmdrop-ui/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.
