### PR TITLE
use StrEnum and ResultE types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [unreleased]
+
+### Added
+
+none
+
+### Changed
+
+- OrderStatusCode and ProviderRole are now StrEnum instead of (str, Enum)
+- All types using `Result[A, Exception]` have been replace with the equivalent type `ResultE[A]`
+
+### Deprecated
+
+none
+
+### Removed
+
+none
+
+### Fixed
+
+none
+
+### Security
+
+none
+
 ## [v0.2.0] - 2024-11-23
 
 ### Added

--- a/bin/server.py
+++ b/bin/server.py
@@ -3,7 +3,7 @@ from uuid import uuid4
 
 from fastapi import FastAPI, Request
 from returns.maybe import Maybe
-from returns.result import Failure, Result, Success
+from returns.result import Failure, ResultE, Success
 
 from stapi_fastapi.backends.product_backend import ProductBackend
 from stapi_fastapi.backends.root_backend import RootBackend
@@ -38,15 +38,13 @@ class MockRootBackend(RootBackend):
     def __init__(self, orders: MockOrderDB) -> None:
         self._orders: MockOrderDB = orders
 
-    async def get_orders(self, request: Request) -> Result[OrderCollection, Exception]:
+    async def get_orders(self, request: Request) -> ResultE[OrderCollection]:
         """
         Show all orders.
         """
         return Success(OrderCollection(features=list(self._orders.values())))
 
-    async def get_order(
-        self, order_id: str, request: Request
-    ) -> Result[Maybe[Order], Exception]:
+    async def get_order(self, order_id: str, request: Request) -> ResultE[Maybe[Order]]:
         """
         Show details for order with `order_id`.
         """
@@ -65,7 +63,7 @@ class MockProductBackend(ProductBackend):
         product_router: ProductRouter,
         search: OpportunityRequest,
         request: Request,
-    ) -> Result[list[Opportunity], Exception]:
+    ) -> ResultE[list[Opportunity]]:
         try:
             return Success(
                 [o.model_copy(update=search.model_dump()) for o in self._opportunities]
@@ -75,7 +73,7 @@ class MockProductBackend(ProductBackend):
 
     async def create_order(
         self, product_router: ProductRouter, payload: OrderRequest, request: Request
-    ) -> Result[Order, Exception]:
+    ) -> ResultE[Order]:
         """
         Create a new order.
         """

--- a/src/stapi_fastapi/backends/product_backend.py
+++ b/src/stapi_fastapi/backends/product_backend.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Protocol
 
 from fastapi import Request
-from returns.result import Result
+from returns.result import ResultE
 
 from stapi_fastapi.models.opportunity import Opportunity, OpportunityRequest
 from stapi_fastapi.models.order import Order, OrderRequest
@@ -16,7 +16,7 @@ class ProductBackend(Protocol):  # pragma: nocover
         product_router: ProductRouter,
         search: OpportunityRequest,
         request: Request,
-    ) -> Result[list[Opportunity], Exception]:
+    ) -> ResultE[list[Opportunity]]:
         """
         Search for ordering opportunities for the  given search parameters.
 
@@ -29,7 +29,7 @@ class ProductBackend(Protocol):  # pragma: nocover
         product_router: ProductRouter,
         search: OrderRequest,
         request: Request,
-    ) -> Result[Order, Exception]:
+    ) -> ResultE[Order]:
         """
         Create a new order.
 

--- a/src/stapi_fastapi/backends/root_backend.py
+++ b/src/stapi_fastapi/backends/root_backend.py
@@ -2,21 +2,19 @@ from typing import Protocol
 
 from fastapi import Request
 from returns.maybe import Maybe
-from returns.result import Result
+from returns.result import ResultE
 
 from stapi_fastapi.models.order import Order, OrderCollection
 
 
 class RootBackend(Protocol):  # pragma: nocover
-    async def get_orders(self, request: Request) -> Result[OrderCollection, Exception]:
+    async def get_orders(self, request: Request) -> ResultE[OrderCollection]:
         """
         Return a list of existing orders.
         """
         ...
 
-    async def get_order(
-        self, order_id: str, request: Request
-    ) -> Result[Maybe[Order], Exception]:
+    async def get_order(self, order_id: str, request: Request) -> ResultE[Maybe[Order]]:
         """
         Get details for order with `order_id`.
 

--- a/src/stapi_fastapi/models/order.py
+++ b/src/stapi_fastapi/models/order.py
@@ -1,4 +1,4 @@
-from enum import Enum
+from enum import StrEnum
 from typing import Any, Generic, Literal, Optional, TypeVar
 
 from geojson_pydantic import Feature, FeatureCollection
@@ -36,7 +36,7 @@ class OrderRequest(BaseModel, Generic[ORP]):
     model_config = ConfigDict(strict=True)
 
 
-class OrderStatusCode(str, Enum):
+class OrderStatusCode(StrEnum):
     received = "received"
     accepted = "accepted"
     rejected = "rejected"

--- a/src/stapi_fastapi/models/product.py
+++ b/src/stapi_fastapi/models/product.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from enum import Enum
+from enum import StrEnum
 from typing import TYPE_CHECKING, Literal, Optional, Self
 
 from pydantic import AnyHttpUrl, BaseModel, Field
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
     from stapi_fastapi.backends.product_backend import ProductBackend
 
 
-class ProviderRole(str, Enum):
+class ProviderRole(StrEnum):
     licensor = "licensor"
     producer = "producer"
     processor = "processor"

--- a/tests/backends.py
+++ b/tests/backends.py
@@ -3,7 +3,7 @@ from uuid import uuid4
 
 from fastapi import Request
 from returns.maybe import Maybe
-from returns.result import Failure, Result, Success
+from returns.result import Failure, ResultE, Success
 
 from stapi_fastapi.backends.product_backend import ProductBackend
 from stapi_fastapi.backends.root_backend import RootBackend
@@ -27,15 +27,13 @@ class MockRootBackend(RootBackend):
     def __init__(self, orders: MockOrderDB) -> None:
         self._orders = orders
 
-    async def get_orders(self, request: Request) -> Result[OrderCollection, Exception]:
+    async def get_orders(self, request: Request) -> ResultE[OrderCollection]:
         """
         Show all orders.
         """
         return Success(OrderCollection(features=list(self._orders.values())))
 
-    async def get_order(
-        self, order_id: str, request: Request
-    ) -> Result[Maybe[Order], Exception]:
+    async def get_order(self, order_id: str, request: Request) -> ResultE[Maybe[Order]]:
         """
         Show details for order with `order_id`.
         """
@@ -53,7 +51,7 @@ class MockProductBackend(ProductBackend):
         product_router: ProductRouter,
         search: OpportunityRequest,
         request: Request,
-    ) -> Result[list[Opportunity], Exception]:
+    ) -> ResultE[list[Opportunity]]:
         return Success(
             [o.model_copy(update=search.model_dump()) for o in self._opportunities]
         )
@@ -63,7 +61,7 @@ class MockProductBackend(ProductBackend):
         product_router: ProductRouter,
         payload: OrderRequest,
         request: Request,
-    ) -> Result[Order, Exception]:
+    ) -> ResultE[Order]:
         """
         Create a new order.
         """


### PR DESCRIPTION
**Related Issue(s):**

- n/a

**Proposed Changes:**

1. replace enums extending `str, Enum` with StrEnum
2. replace `Result[A, Exception]` types with the alias `ResultE[A]`

**PR Checklist:**

- [X] I have added my changes to the [CHANGELOG](https://github.com/Element84/filmdrop-ui/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.
