### PR TITLE
fix conformance versions to 0.1.0 to match stapi-spec versions

### DIFF
--- a/src/stapi_fastapi/models/conformance.py
+++ b/src/stapi_fastapi/models/conformance.py
@@ -1,7 +1,7 @@
 from pydantic import BaseModel, Field
 
-CORE = "https://stapi.example.com/v0.2.0/core"
-OPPORTUNITIES = "https://stapi.example.com/v0.2.0/opportunities"
+CORE = "https://stapi.example.com/v0.1.0/core"
+OPPORTUNITIES = "https://stapi.example.com/v0.1.0/opportunities"
 
 
 class Conformance(BaseModel):


### PR DESCRIPTION
**Related Issue(s):**

- n/a

**Proposed Changes:**

1. Fix conformance URI versions that were accidentally set to 0.2.0 in the last release back to 0.1.0 to match the actual stapi-spec version

**PR Checklist:**

- [X] I have added my changes to the [CHANGELOG](https://github.com/Element84/filmdrop-ui/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.
