### PR TITLE
add support for order statuses endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,35 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- Endpoint `/orders/{order_id}/statuses` supporting `GET` for retrieving statuses. The entity returned by this conforms
+  to the change proposed in [stapi-spec#239](https://github.com/stapi-spec/stapi-spec/pull/239).
+
+- Endpoint `/orders/{order_id}/statuses` supporting `POST` for updating current status
+
+### Changed
+
+- OrderRequest renamed to OrderPayload
+
+### Deprecated
+
+none
+
+### Removed
+
+none
+
+### Fixed
+
+none
+
+### Security
+
+none
+
+## [0.4.0] - 2024-12-11
+
+### Added
+
 none
 
 ### Changed
@@ -44,6 +73,8 @@ none
 
 - OrderStatusCode and ProviderRole are now StrEnum instead of (str, Enum)
 - All types using `Result[A, Exception]` have been replace with the equivalent type `ResultE[A]`
+- Order and OrderCollection extend _GeoJsonBase instead of Feature and FeatureCollection, to allow for tighter
+  constraints on fields
 
 ### Deprecated
 
@@ -75,8 +106,6 @@ none
 - Order field `id` must be a string, instead of previously allowing int. This is because while an
   order ID may an integral numeric value, it is not a "number" in the sense that math will be performed
   order ID values, so string represents this better.
-- Order and OrderCollection extend _GeoJsonBase instead of Feature and FeatureCollection, to allow for tighter
-  constraints on fields
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
-## [0.4.0] - 2024-12-11
+## [unreleased]
 
 ### Added
 
 - Endpoint `/orders/{order_id}/statuses` supporting `GET` for retrieving statuses. The entity returned by this conforms
   to the change proposed in [stapi-spec#239](https://github.com/stapi-spec/stapi-spec/pull/239).
-
 - Endpoint `/orders/{order_id}/statuses` supporting `POST` for updating current status
+- RootBackend has new methods `get_order_statuses` and `set_order_status`
 
 ### Changed
 

--- a/src/stapi_fastapi/backends/product_backend.py
+++ b/src/stapi_fastapi/backends/product_backend.py
@@ -6,7 +6,7 @@ from fastapi import Request
 from returns.result import ResultE
 
 from stapi_fastapi.models.opportunity import Opportunity, OpportunityRequest
-from stapi_fastapi.models.order import Order, OrderRequest
+from stapi_fastapi.models.order import Order, OrderPayload
 from stapi_fastapi.routers.product_router import ProductRouter
 
 
@@ -27,7 +27,7 @@ class ProductBackend(Protocol):  # pragma: nocover
     async def create_order(
         self,
         product_router: ProductRouter,
-        search: OrderRequest,
+        search: OrderPayload,
         request: Request,
     ) -> ResultE[Order]:
         """

--- a/src/stapi_fastapi/backends/root_backend.py
+++ b/src/stapi_fastapi/backends/root_backend.py
@@ -34,7 +34,7 @@ class RootBackend[T: OrderStatusPayload, U: OrderStatus](Protocol):  # pragma: n
 
     async def get_order_statuses(
         self, order_id: str, request: Request
-    ) -> ResultE[list[OrderStatus]]:
+    ) -> ResultE[list[U]]:
         """
         Get statuses for order with `order_id`.
 

--- a/src/stapi_fastapi/backends/root_backend.py
+++ b/src/stapi_fastapi/backends/root_backend.py
@@ -4,7 +4,12 @@ from fastapi import Request
 from returns.maybe import Maybe
 from returns.result import ResultE
 
-from stapi_fastapi.models.order import Order, OrderCollection
+from stapi_fastapi.models.order import (
+    Order,
+    OrderCollection,
+    OrderStatus,
+    OrderStatusPayload,
+)
 
 
 class RootBackend(Protocol):  # pragma: nocover
@@ -21,9 +26,38 @@ class RootBackend(Protocol):  # pragma: nocover
         Should return returns.results.Success[Order] if order is found.
 
         Should return returns.results.Failure[returns.maybe.Nothing] if the order is
-        not found or if access is denied. If there is an Exception associated with attempting to find the order,
-        then resturns.results.Failure[returns.maybe.Some[Exception]] should be returned.
+        not found or if access is denied.
 
-        Typically, a Failure[Nothing] will result in a 404 and Failure[Some[Exception]] will resulting in a 500.
+        A Failure[Exception] will result in a 500.
+        """
+        ...
+
+    async def get_order_statuses(
+        self, order_id: str, request: Request
+    ) -> ResultE[list[OrderStatus]]:
+        """
+        Get statuses for order with `order_id`.
+
+        Should return returns.results.Success[list[OrderStatus]] if order is found.
+
+        Should return returns.results.Failure[Exception] if the order is
+        not found or if access is denied.
+
+        A Failure[Exception] will result in a 500.
+        """
+        ...
+
+    async def set_order_status(
+        self, order_id: str, payload: OrderStatusPayload, request: Request
+    ) -> ResultE[bool]:
+        """
+        Get statuses for order with `order_id`.
+
+        Should return returns.results.Success[list[OrderStatus]] if order is found.
+
+        Should return returns.results.Failure[Exception] if the order is
+        not found or if access is denied.
+
+        A Failure[Exception] will result in a 500.
         """
         ...

--- a/src/stapi_fastapi/backends/root_backend.py
+++ b/src/stapi_fastapi/backends/root_backend.py
@@ -12,7 +12,7 @@ from stapi_fastapi.models.order import (
 )
 
 
-class RootBackend(Protocol):  # pragma: nocover
+class RootBackend[T: OrderStatusPayload, U: OrderStatus](Protocol):  # pragma: nocover
     async def get_orders(self, request: Request) -> ResultE[OrderCollection]:
         """
         Return a list of existing orders.
@@ -48,15 +48,14 @@ class RootBackend(Protocol):  # pragma: nocover
         ...
 
     async def set_order_status(
-        self, order_id: str, payload: OrderStatusPayload, request: Request
-    ) -> ResultE[bool]:
+        self, order_id: str, payload: T, request: Request
+    ) -> ResultE[U]:
         """
-        Get statuses for order with `order_id`.
+        Set statuses for order with `order_id`.
 
-        Should return returns.results.Success[list[OrderStatus]] if order is found.
+        Should return returns.results.Success[OrderStatus] if successful.
 
-        Should return returns.results.Failure[Exception] if the order is
-        not found or if access is denied.
+        Should return returns.results.Failure[Exception] if the status was not able to be set.
 
         A Failure[Exception] will result in a 500.
         """

--- a/src/stapi_fastapi/models/order.py
+++ b/src/stapi_fastapi/models/order.py
@@ -29,17 +29,6 @@ OPP = TypeVar("OPP", bound=OpportunityProperties)
 ORP = TypeVar("ORP", bound=OrderParameters)
 
 
-class OrderRequest(BaseModel, Generic[ORP]):
-    datetime: DatetimeInterval
-    geometry: Geometry
-    # TODO: validate the CQL2 filter?
-    filter: CQL2Filter | None = None
-
-    order_parameters: ORP
-
-    model_config = ConfigDict(strict=True)
-
-
 class OrderStatusCode(StrEnum):
     received = "received"
     accepted = "accepted"
@@ -53,6 +42,11 @@ class OrderStatus(BaseModel):
     status_code: OrderStatusCode
     reason_code: Optional[str] = None
     reason_text: Optional[str] = None
+    links: list[Link] = Field(default_factory=list)
+
+
+class OrderStatuses(BaseModel):
+    statuses: list[OrderStatus]
     links: list[Link] = Field(default_factory=list)
 
 
@@ -115,3 +109,22 @@ class OrderCollection(_GeoJsonBase):
     def __getitem__(self, index: int) -> Order:
         """get feature at a given index"""
         return self.features[index]
+
+
+class OrderPayload(BaseModel, Generic[ORP]):
+    datetime: DatetimeInterval
+    geometry: Geometry
+    # TODO: validate the CQL2 filter?
+    filter: CQL2Filter | None = None
+
+    order_parameters: ORP
+
+    model_config = ConfigDict(strict=True)
+
+
+class OrderStatusPayload(BaseModel):
+    status_code: OrderStatusCode
+    reason_code: Optional[str] = None
+    reason_text: Optional[str] = None
+
+    model_config = ConfigDict(strict=True)

--- a/src/stapi_fastapi/models/order.py
+++ b/src/stapi_fastapi/models/order.py
@@ -44,6 +44,8 @@ class OrderStatus(BaseModel):
     reason_text: Optional[str] = None
     links: list[Link] = Field(default_factory=list)
 
+    model_config = ConfigDict(extra="allow")
+
 
 class OrderStatuses(BaseModel):
     statuses: list[OrderStatus]

--- a/src/stapi_fastapi/models/order.py
+++ b/src/stapi_fastapi/models/order.py
@@ -47,8 +47,8 @@ class OrderStatus(BaseModel):
     model_config = ConfigDict(extra="allow")
 
 
-class OrderStatuses(BaseModel):
-    statuses: list[OrderStatus]
+class OrderStatuses[T: OrderStatus](BaseModel):
+    statuses: list[T]
     links: list[Link] = Field(default_factory=list)
 
 
@@ -59,10 +59,10 @@ class OrderSearchParameters(BaseModel):
     filter: CQL2Filter | None = None
 
 
-class OrderProperties(BaseModel):
+class OrderProperties[T: OrderStatus](BaseModel):
     product_id: str
     created: AwareDatetime
-    status: OrderStatus
+    status: T
 
     search_parameters: OrderSearchParameters
     opportunity_properties: dict[str, Any]
@@ -125,8 +125,9 @@ class OrderPayload(BaseModel, Generic[ORP]):
 
 
 class OrderStatusPayload(BaseModel):
-    status_code: OrderStatusCode
-    reason_code: Optional[str] = None
-    reason_text: Optional[str] = None
+    status_code: OrderStatusCode | None = None
+    reason_code: str | None = None
+    reason_text: str | None = None
 
-    model_config = ConfigDict(strict=True)
+    # todo: rework generic types to allow subclasses to be used correctly, and remove extra=allow
+    model_config = ConfigDict(strict=True, extra="allow")

--- a/src/stapi_fastapi/routers/product_router.py
+++ b/src/stapi_fastapi/routers/product_router.py
@@ -13,7 +13,7 @@ from stapi_fastapi.models.opportunity import (
     OpportunityCollection,
     OpportunityRequest,
 )
-from stapi_fastapi.models.order import Order, OrderRequest
+from stapi_fastapi.models.order import Order, OrderPayload
 from stapi_fastapi.models.product import Product
 from stapi_fastapi.models.shared import Link
 from stapi_fastapi.responses import GeoJSONResponse
@@ -85,13 +85,13 @@ class ProductRouter(APIRouter):
         # the annotation on every `ProductRouter` instance's `create_order`, not just
         # this one's.
         async def _create_order(
-            payload: OrderRequest,
+            payload: OrderPayload,
             request: Request,
             response: Response,
         ) -> Order:
             return await self.create_order(payload, request, response)
 
-        _create_order.__annotations__["payload"] = OrderRequest[
+        _create_order.__annotations__["payload"] = OrderPayload[
             self.product.order_parameters  # type: ignore
         ]
 
@@ -203,7 +203,7 @@ class ProductRouter(APIRouter):
         return self.product.order_parameters
 
     async def create_order(
-        self, payload: OrderRequest, request: Request, response: Response
+        self, payload: OrderPayload, request: Request, response: Response
     ) -> Order:
         """
         Create a new order.

--- a/src/stapi_fastapi/routers/product_router.py
+++ b/src/stapi_fastapi/routers/product_router.py
@@ -7,7 +7,7 @@ from fastapi import APIRouter, HTTPException, Request, Response, status
 from geojson_pydantic.geometries import Geometry
 from returns.result import Failure, Success
 
-from stapi_fastapi.constants import TYPE_GEOJSON, TYPE_JSON
+from stapi_fastapi.constants import TYPE_JSON
 from stapi_fastapi.exceptions import ConstraintsException
 from stapi_fastapi.models.opportunity import (
     OpportunityCollection,
@@ -214,8 +214,8 @@ class ProductRouter(APIRouter):
             request,
         ):
             case Success(order):
+                self.root_router.add_order_links(order, request)
                 location = str(self.root_router.generate_order_href(request, order.id))
-                order.links.append(Link(href=location, rel="self", type=TYPE_GEOJSON))
                 response.headers["Location"] = location
                 return order
             case Failure(e) if isinstance(e, ConstraintsException):

--- a/src/stapi_fastapi/routers/root_router.py
+++ b/src/stapi_fastapi/routers/root_router.py
@@ -3,6 +3,7 @@ from typing import Self
 
 from fastapi import APIRouter, HTTPException, Request, status
 from fastapi.datastructures import URL
+from fastapi.responses import Response
 from returns.maybe import Maybe, Some
 from returns.result import Failure, Success
 
@@ -10,7 +11,12 @@ from stapi_fastapi.backends.root_backend import RootBackend
 from stapi_fastapi.constants import TYPE_GEOJSON, TYPE_JSON
 from stapi_fastapi.exceptions import NotFoundException
 from stapi_fastapi.models.conformance import CORE, Conformance
-from stapi_fastapi.models.order import Order, OrderCollection
+from stapi_fastapi.models.order import (
+    Order,
+    OrderCollection,
+    OrderStatuses,
+    OrderStatusPayload,
+)
 from stapi_fastapi.models.product import Product, ProductsCollection
 from stapi_fastapi.models.root import RootResponse
 from stapi_fastapi.models.shared import Link
@@ -81,6 +87,22 @@ class RootRouter(APIRouter):
             methods=["GET"],
             name=f"{self.name}:get-order",
             response_class=GeoJSONResponse,
+            tags=["Orders"],
+        )
+
+        self.add_api_route(
+            "/orders/{order_id}/statuses",
+            self.get_order_statuses,
+            methods=["GET"],
+            name=f"{self.name}:list-order-statuses",
+            tags=["Orders"],
+        )
+
+        self.add_api_route(
+            "/orders/{order_id}/statuses",
+            self.set_order_status,
+            methods=["POST"],
+            name=f"{self.name}:set-order-status",
             tags=["Orders"],
         )
 
@@ -168,8 +190,20 @@ class RootRouter(APIRouter):
         """
         match await self.backend.get_order(order_id, request):
             case Success(Some(order)):
-                order.links.append(
-                    Link(href=str(request.url), rel="self", type=TYPE_GEOJSON)
+                order.links.extend(
+                    [
+                        Link(href=str(request.url), rel="self", type=TYPE_GEOJSON),
+                        Link(
+                            href=str(
+                                request.url_for(
+                                    f"{self.name}:list-order-statuses",
+                                    order_id=order_id,
+                                )
+                            ),
+                            rel="monitor",
+                            type=TYPE_JSON,
+                        ),
+                    ]
                 )
                 return order
             case Success(Maybe.empty):
@@ -181,6 +215,52 @@ class RootRouter(APIRouter):
                 raise HTTPException(
                     status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
                     detail="Error finding Order",
+                )
+            case _:
+                raise AssertionError("Expected code to be unreachable")
+
+    async def get_order_statuses(
+        self: Self, order_id: str, request: Request
+    ) -> OrderStatuses:
+        match await self.backend.get_order_statuses(order_id, request):
+            case Success(statuses):
+                return OrderStatuses(
+                    statuses=statuses,
+                    links=[
+                        Link(
+                            href=str(
+                                request.url_for(
+                                    f"{self.name}:list-order-statuses",
+                                    order_id=order_id,
+                                )
+                            ),
+                            rel="self",
+                            type=TYPE_JSON,
+                        )
+                    ],
+                )
+            case Failure(e):
+                logging.exception(
+                    "An error occurred while retrieving order statuses", e
+                )
+                raise HTTPException(
+                    status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                    detail="Error finding Order Statuses",
+                )
+            case _:
+                raise AssertionError("Expected code to be unreachable")
+
+    async def set_order_status(
+        self: Self, order_id: str, payload: OrderStatusPayload, request: Request
+    ) -> Response:
+        match await self.backend.set_order_status(order_id, payload, request):
+            case Success(_):
+                return Response(status_code=status.HTTP_202_ACCEPTED)
+            case Failure(e):
+                logging.exception("An error occurred while setting order status", e)
+                raise HTTPException(
+                    status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                    detail="Error setting Order Status",
                 )
             case _:
                 raise AssertionError("Expected code to be unreachable")

--- a/src/stapi_fastapi/routers/root_router.py
+++ b/src/stapi_fastapi/routers/root_router.py
@@ -237,7 +237,7 @@ class RootRouter(APIRouter):
                 raise AssertionError("Expected code to be unreachable")
 
     async def set_order_status(
-        self: Self, order_id: str, payload: OrderStatusPayload, request: Request
+        self, order_id: str, payload: OrderStatusPayload, request: Request
     ) -> Response:
         match await self.backend.set_order_status(order_id, payload, request):
             case Success(_):

--- a/tests/application.py
+++ b/tests/application.py
@@ -63,13 +63,13 @@ class MockRootBackend(RootBackend):
 
     async def set_order_status(
         self, order_id: str, payload: OrderStatusPayload, request: Request
-    ) -> ResultE[bool]:
+    ) -> ResultE[OrderStatus]:
         input = payload.model_dump()
         input["timestamp"] = datetime.now(UTC)
         order_status = OrderStatus.model_validate(input)
         self._orders_db._orders[order_id].properties.status = order_status
         self._orders_db._statuses[order_id].insert(0, order_status)
-        return Success(True)
+        return Success(order_status)
 
 
 class MockProductBackend(ProductBackend):

--- a/tests/application.py
+++ b/tests/application.py
@@ -1,4 +1,5 @@
-from datetime import datetime, timezone
+from collections import defaultdict
+from datetime import UTC, datetime, timezone
 from typing import Literal, Self
 from uuid import uuid4
 
@@ -19,9 +20,10 @@ from stapi_fastapi.models.order import (
     Order,
     OrderCollection,
     OrderParameters,
-    OrderRequest,
+    OrderPayload,
     OrderStatus,
     OrderStatusCode,
+    OrderStatusPayload,
 )
 from stapi_fastapi.models.product import (
     Product,
@@ -32,33 +34,49 @@ from stapi_fastapi.routers.product_router import ProductRouter
 from stapi_fastapi.routers.root_router import RootRouter
 
 
-class MockOrderDB(dict[int | str, Order]):
-    pass
+class InMemoryOrderDB:
+    _orders: dict[str, Order] = {}
+    _statuses: dict[str, list[OrderStatus]] = defaultdict(list)
 
 
 class MockRootBackend(RootBackend):
-    def __init__(self, orders: MockOrderDB) -> None:
-        self._orders: MockOrderDB = orders
+    def __init__(self, orders: InMemoryOrderDB) -> None:
+        self._orders_db: InMemoryOrderDB = orders
 
     async def get_orders(self, request: Request) -> ResultE[OrderCollection]:
         """
         Show all orders.
         """
-        return Success(OrderCollection(features=list(self._orders.values())))
+        return Success(OrderCollection(features=list(self._orders_db._orders.values())))
 
     async def get_order(self, order_id: str, request: Request) -> ResultE[Maybe[Order]]:
         """
         Show details for order with `order_id`.
         """
 
-        return Success(Maybe.from_optional(self._orders.get(order_id)))
+        return Success(Maybe.from_optional(self._orders_db._orders.get(order_id)))
+
+    async def get_order_statuses(
+        self, order_id: str, request: Request
+    ) -> ResultE[list[OrderStatus]]:
+        return Success(self._orders_db._statuses[order_id])
+
+    async def set_order_status(
+        self, order_id: str, payload: OrderStatusPayload, request: Request
+    ) -> ResultE[bool]:
+        input = payload.model_dump()
+        input["timestamp"] = datetime.now(UTC)
+        order_status = OrderStatus.model_validate(input)
+        self._orders_db._orders[order_id].properties.status = order_status
+        self._orders_db._statuses[order_id].insert(0, order_status)
+        return Success(True)
 
 
 class MockProductBackend(ProductBackend):
-    def __init__(self, orders: MockOrderDB) -> None:
+    def __init__(self, orders: InMemoryOrderDB) -> None:
         self._opportunities: list[Opportunity] = []
-        self._allowed_payloads: list[OrderRequest] = []
-        self._orders: MockOrderDB = orders
+        self._allowed_payloads: list[OrderPayload] = []
+        self._orders_db: InMemoryOrderDB = orders
 
     async def search_opportunities(
         self,
@@ -74,22 +92,23 @@ class MockProductBackend(ProductBackend):
             return Failure(e)
 
     async def create_order(
-        self, product_router: ProductRouter, payload: OrderRequest, request: Request
+        self, product_router: ProductRouter, payload: OrderPayload, request: Request
     ) -> ResultE[Order]:
         """
         Create a new order.
         """
         try:
+            status = OrderStatus(
+                timestamp=datetime.now(timezone.utc),
+                status_code=OrderStatusCode.received,
+            )
             order = Order(
                 id=str(uuid4()),
                 geometry=payload.geometry,
                 properties={
                     "product_id": product_router.product.id,
                     "created": datetime.now(timezone.utc),
-                    "status": OrderStatus(
-                        timestamp=datetime.now(timezone.utc),
-                        status_code=OrderStatusCode.accepted,
-                    ),
+                    "status": status,
                     "search_parameters": {
                         "geometry": payload.geometry,
                         "datetime": payload.datetime,
@@ -104,7 +123,8 @@ class MockProductBackend(ProductBackend):
                 links=[],
             )
 
-            self._orders[order.id] = order
+            self._orders_db._orders[order.id] = order
+            self._orders_db._statuses[order.id].insert(0, status)
             return Success(order)
         except Exception as e:
             return Failure(e)
@@ -135,7 +155,7 @@ class MyOrderParameters(OrderParameters):
     s3_path: str | None = None
 
 
-order_db = MockOrderDB()
+order_db = InMemoryOrderDB()
 product_backend = MockProductBackend(order_db)
 root_backend = MockRootBackend(order_db)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,7 +21,7 @@ from stapi_fastapi.models.product import (
 from stapi_fastapi.routers.root_router import RootRouter
 
 from .application import (
-    MockOrderDB,
+    InMemoryOrderDB,
     MockProductBackend,
     MockRootBackend,
     MyOpportunityProperties,
@@ -37,17 +37,17 @@ def base_url() -> Iterator[str]:
 
 
 @pytest.fixture
-def order_db() -> MockOrderDB:
-    return MockOrderDB()
+def order_db() -> InMemoryOrderDB:
+    return InMemoryOrderDB()
 
 
 @pytest.fixture
-def product_backend(order_db: MockOrderDB) -> MockProductBackend:
+def product_backend(order_db: InMemoryOrderDB) -> MockProductBackend:
     return MockProductBackend(order_db)
 
 
 @pytest.fixture
-def root_backend(order_db: MockOrderDB) -> MockRootBackend:
+def root_backend(order_db: InMemoryOrderDB) -> MockRootBackend:
     return MockRootBackend(order_db)
 
 


### PR DESCRIPTION
**Related Issue(s):**

- n/a

**Proposed Changes:**

1. Endpoint `/orders/{order_id}/statuses` supporting `GET` for retrieving statuses. The entity returned by this conforms
  to the change proposed in [stapi-spec#239](https://github.com/stapi-spec/stapi-spec/pull/239).
2. Endpoint `/orders/{order_id}/statuses` supporting `POST` for updating current status
3. RootBackend has new methods `get_order_statuses` and `set_order_status` to support those operations
4. OrderRequest renamed to OrderPayload

**PR Checklist:**

- [X] I have added my changes to the CHANGELOG **or** a CHANGELOG entry is not required.
