### PR TITLE
fix: add args/kwargs support in RootRouter.add_product to configure ProductRouter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Endpoint `/orders/{order_id}/statuses` supporting `GET` for retrieving statuses. The entity returned by this conforms
   to the change proposed in [stapi-spec#239](https://github.com/stapi-spec/stapi-spec/pull/239).
 - RootBackend has new methods `get_order_statuses` and `set_order_status`
+- `*args`/`**kwargs` support in RootRouter's `add_product` allows to configure underlyinging ProductRouter
 
 ### Changed
 

--- a/src/stapi_fastapi/routers/root_router.py
+++ b/src/stapi_fastapi/routers/root_router.py
@@ -235,9 +235,9 @@ class RootRouter(APIRouter):
             case _:
                 raise AssertionError("Expected code to be unreachable")
 
-    def add_product(self: Self, product: Product) -> None:
+    def add_product(self: Self, product: Product, *args, **kwargs) -> None:
         # Give the include a prefix from the product router
-        product_router = ProductRouter(product, self)
+        product_router = ProductRouter(product, self, *args, **kwargs)
         self.include_router(product_router, prefix=f"/products/{product.id}")
         self.product_routers[product.id] = product_router
 


### PR DESCRIPTION
**Related Issue(s):**

- #

**Proposed Changes:**

1. Allow configuring ProductRouter via `*args`/`**kwargs` support in RootRouter's `add_product` method for advanced use cases, i.e. overriding the APIRoute class used (that's our use case at SatVu)

**PR Checklist:**

- [X] I have added my changes to the CHANGELOG **or** a CHANGELOG entry is not required.