### PR TITLE
Add POST method and body to create-order return

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+### Changed
+- Changed method to POST and added body to return of `create-order` link during `search_oppurtunities` calls.
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
 
 ## [v0.5.0] - 2025-01-08
 

--- a/src/stapi_fastapi/routers/product_router.py
+++ b/src/stapi_fastapi/routers/product_router.py
@@ -179,6 +179,8 @@ class ProductRouter(APIRouter):
                             ),
                             rel="create-order",
                             type=TYPE_JSON,
+                            method="POST",
+                            body=search.dict(),
                         ),
                     ],
                 )


### PR DESCRIPTION
**Related Issue(s):**

- # https://github.com/stapi-spec/stapi-fastapi/issues/121

**Proposed Changes:**

1. Add POST method and a body to `create-order` return
2.

**PR Checklist:**

- [x] I have added my changes to the CHANGELOG **or** a CHANGELOG entry is not required.
