### PR TITLE
pin python 3.12 for publishing

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.x"
+          python-version: "3.12"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
**Related Issue(s):**

- n/a

**Proposed Changes:**

1. The default python for gitlab changed to 3.13 recently, so the build-package in python-publish.yml gitlab command now fails because of the 3.12 constraint on the package. Explicitly pinning the publish to 3.12, with the expectation we will update to support 3.13 sometime soon.

**PR Checklist:**

- [X] I have added my changes to the CHANGELOG **or** a CHANGELOG entry is not required.
