### PR TITLE
in backend methods, make Request the last parameter in all methods

### DIFF
--- a/src/stapi_fastapi/backends/product_backend.py
+++ b/src/stapi_fastapi/backends/product_backend.py
@@ -11,7 +11,7 @@ from stapi_fastapi.models.order import Order, OrderPayload
 from stapi_fastapi.routers.product_router import ProductRouter
 
 SearchOpportunities = Callable[
-    [ProductRouter, OpportunityRequest, Request, str | None, int],
+    [ProductRouter, OpportunityRequest, str | None, int, Request],
     Coroutine[Any, Any, ResultE[tuple[list[Opportunity], Maybe[str]]]],
 ]
 """
@@ -21,9 +21,9 @@ search parameters.
 Args:
     product_router (ProductRouter): The product router.
     search (OpportunityRequest): The search parameters.
-    request (Request): FastAPI's Request object.
     next (str | None): A pagination token.
     limit (int): The maximum number of opportunities to return in a page.
+    request (Request): FastAPI's Request object.
 
 Returns:
     A tuple containing a list of opportunities and a pagination token.

--- a/src/stapi_fastapi/backends/root_backend.py
+++ b/src/stapi_fastapi/backends/root_backend.py
@@ -10,16 +10,16 @@ from stapi_fastapi.models.order import (
 )
 
 GetOrders = Callable[
-    [Request, str | None, int],
+    [str | None, int, Request],
     Coroutine[Any, Any, ResultE[tuple[list[Order], Maybe[str]]]],
 ]
 """
 Type alias for an async function that returns a list of existing Orders.
 
 Args:
-    request (Request): FastAPI's Request object.
     next (str | None): A pagination token.
     limit (int): The maximum number of orders to return in a page.
+    request (Request): FastAPI's Request object.
 
 Returns:
     A tuple containing a list of orders and a pagination token.
@@ -49,7 +49,7 @@ T = TypeVar("T", bound=OrderStatus)
 
 
 GetOrderStatuses = Callable[
-    [str, Request, str | None, int],
+    [str, str | None, int, Request],
     Coroutine[Any, Any, ResultE[tuple[list[T], Maybe[str]]]],
 ]
 """
@@ -57,9 +57,9 @@ Type alias for an async function that gets statuses for the order with `order_id
 
 Args:
     order_id (str): The order ID.
-    request (Request): FastAPI's Request object.
     next (str | None): A pagination token.
     limit (int): The maximum number of statuses to return in a page.
+    request (Request): FastAPI's Request object.
 
 Returns:
     A tuple containing a list of order statuses and a pagination token.

--- a/src/stapi_fastapi/routers/product_router.py
+++ b/src/stapi_fastapi/routers/product_router.py
@@ -163,7 +163,7 @@ class ProductRouter(APIRouter):
 
     async def search_opportunities(
         self,
-        search: OpportunityRequest,
+        search: Annotated[OpportunityRequest, Body(embed=True)],
         request: Request,
         next: Annotated[str | None, Body()] = None,
         limit: Annotated[int, Body()] = 10,
@@ -173,7 +173,11 @@ class ProductRouter(APIRouter):
         """
         links: list[Link] = []
         match await self.product._search_opportunities(
-            self, search, request, next, limit
+            self,
+            search,
+            next,
+            limit,
+            request,
         ):
             case Success((features, Some(pagination_token))):
                 links.append(self.order_link(request))

--- a/src/stapi_fastapi/routers/product_router.py
+++ b/src/stapi_fastapi/routers/product_router.py
@@ -163,7 +163,7 @@ class ProductRouter(APIRouter):
 
     async def search_opportunities(
         self,
-        search: Annotated[OpportunityRequest, Body(embed=True)],
+        search: OpportunityRequest,
         request: Request,
         next: Annotated[str | None, Body()] = None,
         limit: Annotated[int, Body()] = 10,

--- a/src/stapi_fastapi/routers/root_router.py
+++ b/src/stapi_fastapi/routers/root_router.py
@@ -181,7 +181,7 @@ class RootRouter(APIRouter):
         self, request: Request, next: str | None = None, limit: int = 10
     ) -> OrderCollection:
         links: list[Link] = []
-        match await self._get_orders(request, next, limit):
+        match await self._get_orders(next, limit, request):
             case Success((orders, Some(pagination_token))):
                 for order in orders:
                     order.links.append(self.order_link(request, order))
@@ -235,7 +235,7 @@ class RootRouter(APIRouter):
         limit: int = 10,
     ) -> OrderStatuses:
         links: list[Link] = []
-        match await self._get_order_statuses(order_id, request, next, limit):
+        match await self._get_order_statuses(order_id, next, limit, request):
             case Success((statuses, Some(pagination_token))):
                 links.append(self.order_statuses_link(request, order_id))
                 links.append(self.pagination_link(request, pagination_token))

--- a/tests/backends.py
+++ b/tests/backends.py
@@ -55,7 +55,7 @@ async def mock_get_order(order_id: str, request: Request) -> ResultE[Maybe[Order
 
 
 async def mock_get_order_statuses(
-    order_id: str, request: Request, next: str | None, limit: int
+    order_id: str, next: str | None, limit: int, request: Request
 ) -> ResultE[tuple[list[OrderStatus], Maybe[str]]]:
     try:
         start = 0
@@ -77,9 +77,9 @@ async def mock_get_order_statuses(
 async def mock_search_opportunities(
     product_router: ProductRouter,
     search: OpportunityRequest,
-    request: Request,
     next: str | None,
     limit: int,
+    request: Request,
 ) -> ResultE[tuple[list[Opportunity], Maybe[str]]]:
     try:
         start = 0

--- a/tests/backends.py
+++ b/tests/backends.py
@@ -21,7 +21,7 @@ from stapi_fastapi.routers.product_router import ProductRouter
 
 
 async def mock_get_orders(
-    request: Request, next: str | None, limit: int
+    next: str | None, limit: int, request: Request
 ) -> ResultE[tuple[list[Order], Maybe[str]]]:
     """
     Return orders from backend.  Handle pagination/limit if applicable


### PR DESCRIPTION
**Related Issue(s):**

- n/a

**Proposed Changes:**

1. In all the backend method signatures, make Request the last parameter, so that all more specific parameter values are before it.

**PR Checklist:**

- [X] I have added my changes to the CHANGELOG **or** a CHANGELOG entry is not required.
