### PR TITLE
Add pagination token + limit to OpportunityRequest model

### DIFF
--- a/src/stapi_fastapi/models/opportunity.py
+++ b/src/stapi_fastapi/models/opportunity.py
@@ -21,9 +21,10 @@ class OpportunityRequest(BaseModel):
     geometry: Geometry
     # TODO: validate the CQL2 filter?
     filter: CQL2Filter | None = None
-    model_config = ConfigDict(strict=True)
     next: str | None = None
     limit: int = 10
+
+    model_config = ConfigDict(strict=True)
 
 
 G = TypeVar("G", bound=Geometry)

--- a/src/stapi_fastapi/models/opportunity.py
+++ b/src/stapi_fastapi/models/opportunity.py
@@ -22,6 +22,8 @@ class OpportunityRequest(BaseModel):
     # TODO: validate the CQL2 filter?
     filter: CQL2Filter | None = None
     model_config = ConfigDict(strict=True)
+    next: str | None = None
+    limit: int = 10
 
 
 G = TypeVar("G", bound=Geometry)

--- a/tests/test_opportunity.py
+++ b/tests/test_opportunity.py
@@ -81,19 +81,17 @@ def test_search_opportunities_pagination(
     end_string = rfc3339_strftime(end, format)
 
     request_payload = {
-        "search": {
-            "geometry": {
-                "type": "Point",
-                "coordinates": [0, 0],
-            },
-            "datetime": f"{start_string}/{end_string}",
-            "filter": {
-                "op": "and",
-                "args": [
-                    {"op": ">", "args": [{"property": "off_nadir"}, 0]},
-                    {"op": "<", "args": [{"property": "off_nadir"}, 45]},
-                ],
-            },
+        "geometry": {
+            "type": "Point",
+            "coordinates": [0, 0],
+        },
+        "datetime": f"{start_string}/{end_string}",
+        "filter": {
+            "op": "and",
+            "args": [
+                {"op": ">", "args": [{"property": "off_nadir"}, 0]},
+                {"op": "<", "args": [{"property": "off_nadir"}, 45]},
+            ],
         },
         "limit": limit,
     }

--- a/tests/test_opportunity.py
+++ b/tests/test_opportunity.py
@@ -24,19 +24,17 @@ def test_search_opportunities_response(
     end_string = rfc3339_strftime(end, format)
 
     request_payload = {
-        "search": {
-            "geometry": {
-                "type": "Point",
-                "coordinates": [0, 0],
-            },
-            "datetime": f"{start_string}/{end_string}",
-            "filter": {
-                "op": "and",
-                "args": [
-                    {"op": ">", "args": [{"property": "off_nadir"}, 0]},
-                    {"op": "<", "args": [{"property": "off_nadir"}, 45]},
-                ],
-            },
+        "geometry": {
+            "type": "Point",
+            "coordinates": [0, 0],
+        },
+        "datetime": f"{start_string}/{end_string}",
+        "filter": {
+            "op": "and",
+            "args": [
+                {"op": ">", "args": [{"property": "off_nadir"}, 0]},
+                {"op": "<", "args": [{"property": "off_nadir"}, 45]},
+            ],
         },
         "limit": 10,
     }


### PR DESCRIPTION
To meet the goal of having all pagination features fully contained within the POST body for `search_opportunities` the `OpportunityRequest` POST model has been updated to include a `limit` and 'next` field.  PR changes here are accounting for and handling the downstream effects of that model change - updating the endpoint and tests.

**Related Issue(s):**

- #

**Proposed Changes:**

1. Adding a `next` and `limit` field to the `OpportunityRequest` POST body model.

**PR Checklist:**

- [ ] I have added my changes to the CHANGELOG **or** a CHANGELOG entry is not required.
