### PR TITLE
refine pagination code, other minor refinements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   token.
 - Moved `OrderCollection` construction from the root backend to the `RootRouter`
   `get_orders` method.
+- Renamed `OpportunityRequest` to `OpportunityPayload` so that would not be confused as
+  being a subclass of the Starlette/FastAPI Request class.
+
+### Fixed
+
+- Opportunities Search result now has the search body in the `create-order` link.
 
 ## [v0.5.0] - 2025-01-08
 

--- a/src/stapi_fastapi/backends/product_backend.py
+++ b/src/stapi_fastapi/backends/product_backend.py
@@ -6,12 +6,12 @@ from fastapi import Request
 from returns.maybe import Maybe
 from returns.result import ResultE
 
-from stapi_fastapi.models.opportunity import Opportunity, OpportunityRequest
+from stapi_fastapi.models.opportunity import Opportunity, OpportunityPayload
 from stapi_fastapi.models.order import Order, OrderPayload
 from stapi_fastapi.routers.product_router import ProductRouter
 
 SearchOpportunities = Callable[
-    [ProductRouter, OpportunityRequest, str | None, int, Request],
+    [ProductRouter, OpportunityPayload, str | None, int, Request],
     Coroutine[Any, Any, ResultE[tuple[list[Opportunity], Maybe[str]]]],
 ]
 """

--- a/src/stapi_fastapi/models/opportunity.py
+++ b/src/stapi_fastapi/models/opportunity.py
@@ -1,4 +1,4 @@
-from typing import Literal, TypeVar
+from typing import Any, Literal, TypeVar
 
 from geojson_pydantic import Feature, FeatureCollection
 from geojson_pydantic.geometries import Geometry
@@ -16,15 +16,21 @@ class OpportunityProperties(BaseModel):
     model_config = ConfigDict(extra="allow")
 
 
-class OpportunityRequest(BaseModel):
+class OpportunityPayload(BaseModel):
     datetime: DatetimeInterval
     geometry: Geometry
-    # TODO: validate the CQL2 filter?
     filter: CQL2Filter | None = None
+
     next: str | None = None
     limit: int = 10
 
     model_config = ConfigDict(strict=True)
+
+    def search_body(self) -> dict[str, Any]:
+        return self.model_dump(mode="json", include={"datetime", "geometry", "filter"})
+
+    def body(self) -> dict[str, Any]:
+        return self.model_dump(mode="json")
 
 
 G = TypeVar("G", bound=Geometry)

--- a/tests/application.py
+++ b/tests/application.py
@@ -15,7 +15,11 @@ from tests.backends import (
     mock_get_order_statuses,
     mock_get_orders,
 )
-from tests.shared import InMemoryOrderDB, mock_product_test_spotlight
+from tests.shared import (
+    InMemoryOrderDB,
+    mock_product_test_satellite_provider,
+    mock_product_test_spotlight,
+)
 
 
 @asynccontextmanager
@@ -35,5 +39,6 @@ root_router = RootRouter(
     conformances=[CORE],
 )
 root_router.add_product(mock_product_test_spotlight)
+root_router.add_product(mock_product_test_satellite_provider)
 app: FastAPI = FastAPI(lifespan=lifespan)
 app.include_router(root_router, prefix="")

--- a/tests/backends.py
+++ b/tests/backends.py
@@ -7,7 +7,7 @@ from returns.result import Failure, ResultE, Success
 
 from stapi_fastapi.models.opportunity import (
     Opportunity,
-    OpportunityRequest,
+    OpportunityPayload,
 )
 from stapi_fastapi.models.order import (
     Order,
@@ -76,7 +76,7 @@ async def mock_get_order_statuses(
 
 async def mock_search_opportunities(
     product_router: ProductRouter,
-    search: OpportunityRequest,
+    search: OpportunityPayload,
     next: str | None,
     limit: int,
     request: Request,

--- a/tests/shared.py
+++ b/tests/shared.py
@@ -1,6 +1,7 @@
 from collections import defaultdict
 from datetime import datetime, timedelta, timezone
 from typing import Any, Literal, Self
+from urllib.parse import parse_qs, urlparse
 from uuid import uuid4
 
 from fastapi import status
@@ -133,7 +134,7 @@ def create_mock_opportunity() -> Opportunity:
 
 def pagination_tester(
     stapi_client: TestClient,
-    endpoint: str,
+    url: str,
     method: str,
     limit: int,
     target: str,
@@ -142,7 +143,7 @@ def pagination_tester(
 ) -> None:
     retrieved = []
 
-    res = make_request(stapi_client, endpoint, method, body, None, limit)
+    res = make_request(stapi_client, url, method, body, limit)
     assert res.status_code == status.HTTP_200_OK
     resp_body = res.json()
 
@@ -151,15 +152,16 @@ def pagination_tester(
     next_url = next((d["href"] for d in resp_body["links"] if d["rel"] == "next"), None)
 
     while next_url:
-        url = next_url
         if method == "POST":
             body = next(
                 (d["body"] for d in resp_body["links"] if d["rel"] == "next"), None
             )
 
-        res = make_request(stapi_client, url, method, body, next_url, limit)
-        assert res.status_code == status.HTTP_200_OK
+        res = make_request(stapi_client, next_url, method, body, limit)
+
+        assert res.status_code == status.HTTP_200_OK, res.status_code
         assert len(resp_body[target]) <= limit
+
         resp_body = res.json()
         retrieved.extend(resp_body[target])
 
@@ -177,22 +179,25 @@ def pagination_tester(
 
 def make_request(
     stapi_client: TestClient,
-    endpoint: str,
+    url: str,
     method: str,
     body: dict | None,
-    next_token: str | None,
     limit: int,
 ) -> Response:
     """request wrapper for pagination tests"""
 
     match method:
         case "GET":
-            if next_token:  # extract pagination token
-                next_token = next_token.split("next=")[1]
-            params = {"next": next_token, "limit": limit}
-            res = stapi_client.get(endpoint, params=params)
+            o = urlparse(url)
+            base_url = f"{o.scheme}://{o.netloc}{o.path}"
+            parsed_qs = parse_qs(o.query)
+            params = {}
+            if "next" in parsed_qs:
+                params["next"] = parsed_qs["next"][0]
+            params["limit"] = int(parsed_qs.get("limit", [None])[0] or limit)
+            res = stapi_client.get(base_url, params=params)
         case "POST":
-            res = stapi_client.post(endpoint, json=body)
+            res = stapi_client.post(url, json=body)
         case _:
             fail(f"method {method} not supported in make request")
 

--- a/tests/test_opportunity.py
+++ b/tests/test_opportunity.py
@@ -96,7 +96,7 @@ def test_search_opportunities_pagination(
 
     pagination_tester(
         stapi_client=stapi_client,
-        endpoint=f"/products/{product_id}/opportunities",
+        url=f"/products/{product_id}/opportunities",
         method="POST",
         limit=limit,
         target="features",

--- a/tests/test_order.py
+++ b/tests/test_order.py
@@ -170,16 +170,20 @@ def test_get_orders_pagination(
     limit, setup_orders_pagination, create_order_payloads, stapi_client: TestClient
 ) -> None:
     expected_returns = []
-    if limit != 0:
+    if limit > 0:
         for order in setup_orders_pagination:
-            json_link = copy.deepcopy(order["links"][0])
-            json_link["type"] = "application/json"
-            order["links"].append(json_link)
+            self_link = copy.deepcopy(order["links"][0])
+            order["links"].append(self_link)
+            monitor_link = copy.deepcopy(order["links"][0])
+            monitor_link["rel"] = "monitor"
+            monitor_link["type"] = "application/json"
+            monitor_link["href"] = monitor_link["href"] + "/statuses"
+            order["links"].append(monitor_link)
             expected_returns.append(order)
 
     pagination_tester(
         stapi_client=stapi_client,
-        endpoint="/orders",
+        url="/orders",
         method="GET",
         limit=limit,
         target="features",
@@ -233,7 +237,7 @@ def test_get_order_status_pagination(
 
     pagination_tester(
         stapi_client=stapi_client,
-        endpoint=f"/orders/{order_id}/statuses",
+        url=f"/orders/{order_id}/statuses",
         method="GET",
         limit=limit,
         target="statuses",

--- a/tests/test_product.py
+++ b/tests/test_product.py
@@ -111,7 +111,7 @@ def test_get_products_pagination(
 
     pagination_tester(
         stapi_client=stapi_client,
-        endpoint="/products",
+        url="/products",
         method="GET",
         limit=limit,
         target="products",


### PR DESCRIPTION
**Related Issue(s):**

- https://github.com/stapi-spec/stapi-fastapi/issues/121

**Proposed Changes:**

- add body to create-order link in Opportunities Search result
- refine pagination code
- rename OpportunityRequest to OpportunityPayload - this makes it so it won't be confused with the starlette/fastapi Request class and the Payload part aligns it with other POST body model names

**PR Checklist:**

- [X] I have added my changes to the CHANGELOG **or** a CHANGELOG entry is not required.
